### PR TITLE
기존 branch(main) reset & webpack.config.ts 변경 & Detail.tsx 생성

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import DiscordLogin from './components/buttons/DiscordLogin';
+import Detail from './pages/Detail';
 import Home from './pages/Home';
 
 const _Routes = () => {
@@ -7,6 +8,7 @@ const _Routes = () => {
     <Routes>
       <Route path="/" element={<Home />}>
         <Route index element={<DiscordLogin />} />
+        <Route path="/detail" element={<Detail />} />
         <Route path="*" element={<Navigate to="/" />} />
       </Route>
     </Routes>

--- a/src/features/oauth2/oauth2DiscordSlice.ts
+++ b/src/features/oauth2/oauth2DiscordSlice.ts
@@ -1,0 +1,11 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {};
+
+const oauth2DiscordSlice = createSlice({
+  name: 'oauth2Discord',
+  initialState,
+  reducers: {},
+});
+
+export default oauth2DiscordSlice.reducer;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,0 +1,10 @@
+const Detail = () => {
+    return (
+      <button>
+          글씨
+      </button>
+    );
+  };
+  
+  export default Detail;
+  

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { useDispatch } from 'react-redux';
+
+const store = configureStore({
+  reducer: {},
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+export const useAppDispatch = () => useDispatch<AppDispatch>(); // Export a hook that can be reused to resolve types
+
+export default store;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,7 +10,7 @@ const config: webpack.Configuration = {
   mode: 'development',
   entry: './src/index.tsx',
   devServer: {
-    port: 3000,
+    port: 8080,
     client: {
       overlay: {
         warnings: false,


### PR DESCRIPTION
- commit 1.  **feat: add redux reducer and store**

제가 PR을 까먹었어서

dev-chae에 push를 하는 것이 실수로 main에 push를 해서 이걸 되돌린다고
git reset HEAD^ 명령어로
main과 dev-chae를 예전으로 되돌렸어요...


- commit 2.  **chore: modify webpack.config due to change port(8080)**

yarn start를 진행할 때 port가 default인 3000으로 접속 되어

webpack.config.ts 에 포트번호를 8080으로 변경했습니다.


- commit 3.  **feat: create src/pages/Detail.tsx**

Detail.tsx을 pages 하단에 파일을 생성하였으며
이 파일은 차후에 디테일(대시보드) 페이지로 활용하기 위해 생성하였습니다!



