### PR TITLE
CI/CD stg 환경 추가

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -88,6 +88,14 @@ jobs:
           EOF
           NODE_ENV=production yarn build
 
+      - name: Build STG bundle
+        if: steps.restore_bundle.outputs.cache-hit == 'false' && github.ref == 'refs/heads/main'
+        run: |
+          cat << EOF >> .env
+          ${{ secrets.ENV_STG }}
+          EOF
+          NODE_ENV=production yarn build
+
       - name: Build PRD bundle
         if: steps.restore_bundle.outputs.cache-hit == 'false' && github.ref_type == 'tag'
         run: |
@@ -125,6 +133,13 @@ jobs:
           docker run -itd --name minio_client -v "$(pwd)"/dist:/dist --entrypoint=/bin/sh minio/mc
           docker exec minio_client mc alias set koo $MINIO_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
           docker exec minio_client mc cp -r dist/ koo/dev
+
+      - name: Deploy to stg
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker run -itd --name minio_client -v "$(pwd)"/dist:/dist --entrypoint=/bin/sh minio/mc
+          docker exec minio_client mc alias set koo $MINIO_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+          docker exec minio_client mc cp -r dist/ koo/stg
 
       - name: Deploy to prd 
         if: github.ref_type == 'tag'


### PR DESCRIPTION
## 변경사항

- CI/CD stg 환경 추가
  - 백엔드가 dev/prd 로 나누어 져도 메인 브랜치는 stg 환경 바라보고 stg 환경은 백엔드 prd의 api 엔드포인트 바라보게 해두어도 될 것 같아서 롤백했습니다.

## 참고사항
x